### PR TITLE
'public' and 'private' keywords are a problem if using Google Closure

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ Start by generating two RSA keypairs:
 
 ``` js
 var key = require("ursa").generatePrivateKey();
-require('fs').writeFileSync("./operator.json", JSON.stringify({public:key.toPublicPem("utf8"), private:key.toPrivatePem("utf8")}, null, 4));
+require('fs').writeFileSync("./operator.json", JSON.stringify({publicKey:key.toPublicPem("utf8"), privateKey:key.toPrivatePem("utf8")}, null, 4));
 var key = require("ursa").generatePrivateKey();
-require('fs').writeFileSync("./client.json", JSON.stringify({public:key.toPublicPem("utf8"), private:key.toPrivatePem("utf8")}, null, 4));
+require('fs').writeFileSync("./client.json", JSON.stringify({publicKey:key.toPublicPem("utf8"), privateKey:key.toPrivatePem("utf8")}, null, 4));
 ```
 
 Then start up the operator:
@@ -29,9 +29,9 @@ console.log("operator address is ", operator.address);
 // operators need to resolve other keys in the same space, so provide a callback to do that for our client.json
 // this is typically done via a key-value store or other means dynamically, here we only have one
 var ckeys = require("./client.json");
-var chashname = tele.hash(ckeys.public+"testing.private").toString();
+var chashname = tele.hash(ckeys.publicKey+"testing.private").toString();
 operator.myLookup(function(hashname, callback){
-	if (hashname === chashname) return callback(null, ckeys.public);
+	if (hashname === chashname) return callback(null, ckeys.publicKey);
 	callback("not found");
 });
 ```
@@ -56,7 +56,7 @@ client.setOperators([opaddress]);
 // ask for ourselves, which will query the operator
 client.doWho(client.hashname, function(err, pubkey){
 	if(err) return console.log("failed to find our hashname in this space:", err);
-	if(pubkey !== ckeys.public) return console.log("odd, our keys didn't match"); 
+	if(pubkey !== ckeys.publicKey) return console.log("odd, our keys didn't match"); 
 	console.log("great, we're connected! our address is", client.address);
 });
 ```

--- a/demo/anya.js
+++ b/demo/anya.js
@@ -19,7 +19,7 @@ client.setProxy({host:"jeremie.com", port:80});
 // ask for ourselves, which will query the operator
 client.doVerify(client.hashname, function(err, pubkey){
 	if(err) return console.log("failed to find our hashname in this space:", err);
-	if(pubkey !== ckeys.public) return console.log("odd, our keys didn't match", pubkey, ckeys.public); 
+	if(pubkey !== ckeys.publicKey) return console.log("odd, our keys didn't match", pubkey, ckeys.publicKey); 
 	console.log("great, we're connected! our address is", client.address);
 	client.doLine(opaddress.split(",")[0], function(err){
   	if(err) return console.log("failed to open line:", err);

--- a/demo/client.js
+++ b/demo/client.js
@@ -16,6 +16,6 @@ client.setOperators([opaddress]);
 // ask for ourselves, which will query the operator
 client.doWho(client.hashname, function(err, pubkey){
 	if(err) return console.log("failed to find our hashname in this space:", err);
-	if(pubkey !== ckeys.public) return console.log("odd, our keys didn't match"); 
+	if(pubkey !== ckeys.publicKey) return console.log("odd, our keys didn't match"); 
 	console.log("great, we're connected! our address is", client.address);
 });

--- a/demo/genkeys.js
+++ b/demo/genkeys.js
@@ -1,4 +1,4 @@
 var key = require("ursa").generatePrivateKey();
-require('fs').writeFileSync("./operator.json", JSON.stringify({public:key.toPublicPem("utf8"), private:key.toPrivatePem("utf8")}, null, 4));
+require('fs').writeFileSync("./operator.json", JSON.stringify({publicKey:key.toPublicPem("utf8"), privateKey:key.toPrivatePem("utf8")}, null, 4));
 var key = require("ursa").generatePrivateKey();
-require('fs').writeFileSync("./client.json", JSON.stringify({public:key.toPublicPem("utf8"), private:key.toPrivatePem("utf8")}, null, 4));
+require('fs').writeFileSync("./client.json", JSON.stringify({publicKey:key.toPublicPem("utf8"), privateKey:key.toPrivatePem("utf8")}, null, 4));

--- a/demo/operator.js
+++ b/demo/operator.js
@@ -8,8 +8,8 @@ console.log("operator address is ", operator.address);
 // operators need to resolve other keys in the same space, so provide a callback to do that for our client.json
 // this is typically done via a key-value store or other means dynamically, here we only have one
 var ckeys = require("./client.json");
-var chashname = tele.hash(ckeys.public+"testing.private").toString();
+var chashname = tele.hash(ckeys.publicKey+"testing.private").toString();
 operator.myLookup(function(hashname, callback){
-	if (hashname === chashname) return callback(null, ckeys.public);
+	if (hashname === chashname) return callback(null, ckeys.publicKey);
 	callback("not found");
 });

--- a/telehash.js
+++ b/telehash.js
@@ -23,14 +23,14 @@ exports.hash = function(string)
 // start a hashname listening and ready to go
 exports.hashname = function(space, keys, args)
 {
-  if(!space || !keys || !keys.public || !keys.private) return undefined;
+  if(!space || !keys || !keys.publicKey || !keys.privateKey) return undefined;
   if(!args) args = {};
 
   // configure defaults
   var self = {space:space, cb:{}, operators:[], watch:{}, lines:{}, lineq:[], seen:{}, buckets:[]};
   // parse/validate the private key
-  self.prikey = keys.private;
-  self.pubkey = keys.public;
+  self.prikey = keys.privateKey;
+  self.pubkey = keys.publicKey;
   self.hash = new dhash.Hash(self.pubkey+space);
   self.hashname = self.hash.toString();
   if (!args.ip || args.natted) self.nat = true;


### PR DESCRIPTION
I am testing the library with ClojureScript, which is internally using Google Closure. However, Google Closure throws an error if you use 'public' as a property name. Also, 'public' and 'private' are FutureReservedWords in strict mode of ECMAScript:

See http://www.ecma-international.org/ecma-262/5.1/#sec-7.6.1.2

So, I changed the properties 'public' and 'private' to 'publicKey' and 'privateKey'.

Best Regards
Stephen Kockentiedt
